### PR TITLE
Caiman update

### DIFF
--- a/ncap_iac/ncap_blueprints/caiman_web_stack/stack_config_template.json
+++ b/ncap_iac/ncap_blueprints/caiman_web_stack/stack_config_template.json
@@ -9,7 +9,7 @@
         "PostHandler": "postprocess.epipostprocess",
         "Launch": true,
         "LambdaConfig": {
-            "AMI": "ami-0954b36a98d51d7c5",
+            "AMI": "ami-045bdb48658041dbd",
             "INSTANCE_TYPE": "m5.16xlarge",
             "REGION": "us-east-1",
             "SECURITY_GROUPS": "testsgstack-SecurityGroupDeploy-C2Q3PGSF77Y3",


### PR DESCRIPTION
When CaImAn evaluates components and discards them it calculates an r value that measures correlation (between components)? Sometimes, this can throw a nan, which causes issues when saving the cnmf object- specifically in the attribute`estimates.discarded_components.r_values`(there is a check in the saving process to ensure that we are saving what we intend to). This check evaluates to false when asking if two instances of the same object that include a nan are actually equal. 

We get around this by including a try-except block around the saving of the cnmf object. Later on we can check if we are actually lose anything by including this check. 