### PR TITLE
add webrtc blueprint

### DIFF
--- a/ncap_iac/ncap_blueprints/neurocaas_livestream/stack_config_template.json
+++ b/ncap_iac/ncap_blueprints/neurocaas_livestream/stack_config_template.json
@@ -1,0 +1,48 @@
+{
+    "PipelineName": "neurocaas-livestream",
+    "REGION": "us-east-1",
+    "STAGE": "websubstack",
+    "Lambda": {
+        "CodeUri": "../../protocols",
+        "Handler": "submit_start.handler_develop",
+        "Launch": true,
+        "LambdaConfig": {
+            "AMI": "ami-08420afa05e60fd37",
+            "INSTANCE_TYPE": "p3.2xlarge",
+            "REGION": "us-east-1",
+            "SECURITY_GROUPS": "neurocaas_rtmp",
+            "IAM_ROLE": "SSMRole",
+            "KEY_NAME": "testkeystack-custom-dev-key-pair",
+            "WORKING_DIRECTORY": "/home/ubuntu",
+            "COMMAND": "ls; cd /home/ubuntu; neurocaas_contrib/run_main_cli.sh \"{}\" \"{}\" \"{}\" \"{}\" \"neurocaas_contrib/ncap_live/run_webrtc_cli.sh\"; . neurocaas_contrib/ncap_utils/workflow.sh; cleanup",
+            "SHUTDOWN_BEHAVIOR": "terminate",
+            "CONFIG": "config.yaml",
+            "MISSING_CONFIG_ERROR": "We need a config file to analyze data.",
+            "EXECUTION_TIMEOUT": 900,
+            "SSM_TIMEOUT": 172000,
+            "LAUNCH": true,
+            "LOGFILE": "lambda_log.txt",
+            "DEPLOY_LIMIT": 300,
+            "MAXCOST": 600,
+            "MONITOR": true,
+            "LOGDIR": "logs",
+            "OUTDIR": "results",
+            "INDIR": "inputs"
+        }
+    },
+    "UXData": {
+        "Affiliates": [
+            {
+                "AffiliateName": "traviscipermagroup",
+                "UserNames": [
+                    "cipermauser1",
+		            "cipermauser2"
+                ],
+                "PipelinePath": "",
+                "PipelineDir": "trackingfolder",
+                "UserInput": true,
+                "ContactEmail": "The email we should notify regarding processing status."
+            }
+        ]
+    }
+}


### PR DESCRIPTION
A new blueprint containing the pipeline to run WebRTC has been added.
It also allows running RTSP, but you need to change the bash script that runs WebRTC to the one that runs RTSP.

![image](https://user-images.githubusercontent.com/1589267/138938750-d3eacde5-f84d-4c30-8019-75ffa19dc093.png)

you need to change `run_webrtc_cli.sh` to `run_rtsp_zmq_cli.sh`. 

These files can be found in the [PR 30](https://github.com/cunningham-lab/neurocaas_contrib/pull/30) at neurocaas_contrib

