### PR TITLE
Caiman update

### DIFF
--- a/ncap_iac/ncap_blueprints/caiman_web_stack/stack_config_template.json
+++ b/ncap_iac/ncap_blueprints/caiman_web_stack/stack_config_template.json
@@ -9,7 +9,7 @@
         "PostHandler": "postprocess.epipostprocess",
         "Launch": true,
         "LambdaConfig": {
-            "AMI": "ami-045bdb48658041dbd",
+            "AMI": "ami-0dff2652743d0d598",
             "INSTANCE_TYPE": "m5.16xlarge",
             "REGION": "us-east-1",
             "SECURITY_GROUPS": "testsgstack-SecurityGroupDeploy-C2Q3PGSF77Y3",

--- a/ncap_iac/ncap_blueprints/caiman_web_stack/stack_config_template.json
+++ b/ncap_iac/ncap_blueprints/caiman_web_stack/stack_config_template.json
@@ -9,7 +9,7 @@
         "PostHandler": "postprocess.epipostprocess",
         "Launch": true,
         "LambdaConfig": {
-            "AMI": "ami-0dff2652743d0d598",
+            "AMI": "ami-048a58403daf0ae23",
             "INSTANCE_TYPE": "m5.16xlarge",
             "REGION": "us-east-1",
             "SECURITY_GROUPS": "testsgstack-SecurityGroupDeploy-C2Q3PGSF77Y3",

--- a/ncap_iac/ncap_blueprints/caiman_web_stack/stack_config_template.json
+++ b/ncap_iac/ncap_blueprints/caiman_web_stack/stack_config_template.json
@@ -24,7 +24,7 @@
             "SSM_TIMEOUT": 172000,
             "LAUNCH": true,
             "LOGFILE": "lambda_log.txt",
-            "DEPLOY_LIMIT": 10,
+            "DEPLOY_LIMIT": 100,
             "MAXCOST": 300,
             "MONITOR": true,
             "LOGDIR": "logs",


### PR DESCRIPTION
Revision to update handling to accept tar.gz files. 

Assumptions: 
- first file in directory will be the folder to which these files will be unpacked. 
- file sizes are large- will be segmented into length 100 tifs for processing. 

Workflow: 
- if extension is `.tar.gz`, 
  - 1. unpack files into the `ncapdata/localdata` directory. 
  - 2. combine single tif files into multipage tifs of bounded size. (https://caiman.readthedocs.io/en/master/On_file_types_and_sizes.html)
  - 3. take file paths and pass to `mov_names`

 

   
  

    








