### PR TITLE
Storage bypass

### DIFF
--- a/docs/source/user/cli.rst
+++ b/docs/source/user/cli.rst
@@ -78,6 +78,8 @@ You can start a job by saving your submit file as any file suffixed as :code:`su
 
 Note that this file is generated automatically when you click the "submit" button on the NeuroCAAS website.
 
+
+
 Monitoring Jobs
 ~~~~~~~~~~~~~~~
 
@@ -94,5 +96,27 @@ Downloading Results
 Finally, all results that your analysis generates will be sent to the folder :code:`s3://caiman-ncap-web/user1/results/job__caiman-ncap-web_{unique_timestamp}/process_results`. You can download them all at once with the command :code:`aws s3 sync s3://caiman-ncap-web/user1/results/job__caiman-ncap-web_{unique_timestamp}/process_results/ /path/to/local/location/`. Note that when processing finishes, it will upload a file called :code:`end.txt` to the :code:`process_results` folder, which you can monitor for to detect if the analysis is done.   
 
 
+Advanced Usage
+--------------
 
+Storage Bypass (June 9th, 2022)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+If you have especially large datasets or analysis outputs, it may be prohibitively slow to first transfer them to NeuroCAAS, analyze them, and remove the analysis outputs, especially as we do not allow users to use NeuroCAAS itself to analyze data. For these cases, we can offer a "Storage Bypass" option: if you have access to your data in a publically accessible S3 bucket, you can read and write directly to that bucket. Timestamped outputs and logs will be delivered back to the storage location of your choice. In order to make use of this feature, modify your submit files as follows: 
+
+.. code-block:: json
+
+    {
+        dataname: [s3://inputbucket/sep_inputs/file.ext],
+        configname: [s3://inputbucket/sep_configs/configsep.json],
+        timestamp: timestamp
+        [resultpath: s3://outputbucket/sep_results], 
+    }
+
+Modifications to the original submit file format are presented in brackets. Note that here we assume the following: 
+
+- data and configuration files come from a public bucket, and can be accessed by anyone.
+- data and config must come from the same input bucket, but no longer require an explicit group
+- results will be written to a subfolder of the optionally different output bucket.
+
+Finally, older analyses last deployed before this feature will need to be updated in order to work correctly with it. We are actively updating analyses at this time to standardize interfaces across analyses, but if you encounter any issues please contact neurocaas@gmail.com and we can expedite updates. 

--- a/ncap_iac/ncap_blueprints/dgp-refactor/stack_config_template.json
+++ b/ncap_iac/ncap_blueprints/dgp-refactor/stack_config_template.json
@@ -7,7 +7,7 @@
         "Handler": "submit_start.handler_develop",
         "Launch": true,
         "LambdaConfig": {
-            "AMI": "ami-0cd1336c0bb8761d1",
+            "AMI": "ami-07829a772419a2569",
             "INSTANCE_TYPE": "p3.2xlarge",
             "REGION": "us-east-1",
             "SECURITY_GROUPS": "testsgstack-SecurityGroupDeploy-C2Q3PGSF77Y3",

--- a/ncap_iac/protocols/submit_start.py
+++ b/ncap_iac/protocols/submit_start.py
@@ -98,7 +98,7 @@ class Submission_dev():
         self.jobpath = jobpath
         try:
             ## And create a corresponding directory in the submit area. 
-            create_jobdir  = utilsparams3.mkdir(self.bucket_name, os.path.join(self.path,os.environ['OUTDIR']),self.jobname)
+            create_jobdir  = utilsparams3.mkdir(self.bucket_name, os.path.dirname(self.jobpath),os.path.basename(self.jobpath))
 
             ## Create a logging object and write to it. 
             ## a logger for the submit area.  

--- a/ncap_iac/protocols/submit_start.py
+++ b/ncap_iac/protocols/submit_start.py
@@ -555,7 +555,7 @@ class Submission_dev():
         if self.bypass_data["output"]["bucket"] is not None:
             output_bucket = self.bypass_data["output"]["bucket"]
             result_check_paths = self.bypass_data["output"]["resultpath"]
-            outpath_full = "s3://{}/{}".format(output_bucket,result_check_paths)
+            outpath_full = "s3://{}/{}".format(output_bucket,os.path.join(result_check_paths,self.jobname))
         else:    
             outpath_full = os.path.join(os.environ['OUTDIR'],self.jobname)
 

--- a/tests/protocol_tests/test_submit_start.py
+++ b/tests/protocol_tests/test_submit_start.py
@@ -171,6 +171,12 @@ def setup_testing_bucket(monkeypatch):
                 "dataname":[os.path.join(user_name,"inputs","data1.json") for d in range(10)],
                 "configname":os.path.join(user_name,"configs","durationnoneconfig.json"),
                 "timestamp":"testtimestamp"},
+            ## new: bucket skip. 
+            "submissions/bucketskipsubmit.json":{
+                "dataname":[os.path.join("s3://{}".format(bucket_name),user_name,"inputs","data1.json") for d in range(10)],
+                "configname":os.path.join("s3://{}".format(bucket_name),user_name,"configs","durationnoneconfig.json"),
+                "timestamp":"testtimestamp",
+                "resultpath":"s3://{}/path/to/here".format(bucket_name)}
             }
 
     session = localstack_client.session.Session()
@@ -391,6 +397,10 @@ class Test_Submission_dev():
         with pytest.raises(ValueError):
             sd = submit_start.Submission_dev(bucket_name,notimestampkey_name,"111111111")
 
+    def test_Submission_dev_skip(self,setup_lambda_env,setup_testing_bucket,check_instances):
+        ## set up the os environment correctly. 
+        bucket_name,submit_path = setup_testing_bucket[0],setup_testing_bucket[1]
+        sd = submit_start.Submission_dev(bucket_name,os.path.join(os.path.join(os.path.dirname(submit_path),"bucketskipsubmit.json"),"111111111"))
 
 ### Testing check_existence. 
     @pytest.mark.parametrize("submitname,path",[("submit.json",[os.path.join("test_user/inputs/",d) for d in ["data1.json","data2.json"]]),("singlesubmit.json",[os.path.join("test_user/inputs/","data1.json")])])

--- a/tests/protocol_tests/test_submit_start.py
+++ b/tests/protocol_tests/test_submit_start.py
@@ -671,7 +671,7 @@ class Test_Submission_dev():
         sd.acquire_instances()
         #sd.start_instance()
         commands = sd.process_inputs(dryrun=True)
-        assert commands[0] == os.environ["COMMAND"].format(sep_bucket,"sep_inputs/datasep.json","s3://independent/sep_results","sep_configs/configsep.json")
+        assert commands[0] == os.environ["COMMAND"].format(sep_bucket,"sep_inputs/datasep.json","s3://independent/sep_results/job__test-submitlambda-analysis_testtimestamp","sep_configs/configsep.json")
         info= ec2_client.describe_instances(InstanceIds = [i.id for i in sd.instances])
         #for instanceinfo in info["Reservations"][0]["Instances"]:
         #    tags = instanceinfo["Tags"]


### PR DESCRIPTION
Embedding storage bypass options into default job manager. CLI based usage will now be able to accept submissions like this: 
```
{
dataname: [s3://inputbucket/sep_inputs/file.ext]
configname: [s3://inputbucket/sep_configs/configsep.json]
timestamp: timestamp
[resultpath: s3://outputbucket/sep_results] 
}
```
Where: 
- it's assumed data comes from a public bucket, and can be accessed by anyone. 
- data and config must come from the same input bucket, but no longer require an explicit group
- results will be written to a subfolder of the optionally different output bucket. 


Correspondingly, IAEs will recieve commands like this: 
```
cd /home/ubuntu; neurocaas_remote/run_main.sh "inputbucket" "sep_inputs/file.ext" "s3://outputbucket/sep_results" "sep_configs/configsep.json"; . neurocaas_remote/ncap_utils/workflow.sh; cleanup'
```

Note that individual analysis IAEs will have to handle these commands- in particular, the formatting of the results (previously just giving a prefix, without the bucket name) is different. We have a corresponding update to the contrib repo to address this. 
