### PR TITLE
Expanding dev permissions

### DIFF
--- a/ncap_iac/utils/dev_builder.py
+++ b/ncap_iac/utils/dev_builder.py
@@ -861,6 +861,7 @@ class WebDevTemplate(NeuroCaaSTemplate):
             'Resource': ['arn:aws:s3:::'+bucketname+'/'+affiliatename+'/'+indir+'/*',
                          'arn:aws:s3:::'+bucketname+'/'+affiliatename+'/'+condir+'/*',
                          'arn:aws:s3:::'+bucketname+'/'+affiliatename+'/'+subdir+'/*'
+                         'arn:aws:s3:::'+bucketname+'/'+affiliatename+'/'+outdir+'/*', ## Need to write to the output directory within the output  
                          ]
              })
         


### PR DESCRIPTION
added permissions to write to the results directory for those who are manually added. Closes https://github.com/cunningham-lab/neurocaas/issues/120, and is already consistent with guidance given in developer repo. 