### PR TITLE
updated to webdev mode.

### DIFF
--- a/ncap_iac/ncap_blueprints/radical/stack_config_template.json
+++ b/ncap_iac/ncap_blueprints/radical/stack_config_template.json
@@ -1,7 +1,7 @@
 {
     "PipelineName": "radical-snel",
     "REGION": "us-east-1",
-    "STAGE": "webdev",
+    "STAGE": "websubstack",
     "Lambda": {
         "CodeUri": "../../protocols",
         "Handler": "submit_start.handler_develop",


### PR DESCRIPTION
Radical was previously still in websubstack mode, which meant that users who were auto-approved from the neurocaas website did not automatically get the appropriate permissions to use the underlying AWS analysis.